### PR TITLE
Add the current beta server as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Compile and test with:
 
     mvn -Dserver=... -DapiID=... -DappKey=... clean test install
 
+The current beta test server can be tested against using:
+
+    -Dserver=https://beta.openphacts.org/1.3/
 
 Example
 =======


### PR DESCRIPTION
It took me a little while to figure out what -Dserver= should be, as it doesn't really say it in the API docs. Had to perform a sample action at the docs page https://dev.openphacts.org/docs/1.3 and see where it was sending the request!

Added this as an example for other users to the README.md file.
