### PR TITLE
In tests, default 'server' 'appID' & 'appKey' to OS environment values.

### DIFF
--- a/src/test/java/com/github/egonw/ops4j/AbstractOPS4JTest.java
+++ b/src/test/java/com/github/egonw/ops4j/AbstractOPS4JTest.java
@@ -29,9 +29,9 @@ abstract class AbstractOPS4JTest {
 	protected String appKey;
 
 	public void pickUpConfig() {
-		server = System.getProperty("server", "");
-		appID = System.getProperty("appID", "");
-		appKey = System.getProperty("appKey", "");
+        server = System.getProperty("server", System.getenv( "OPS4J_server" ));
+        appID = System.getProperty("appID", System.getenv( "OPS4J_appID" ));
+        appKey = System.getProperty("appKey", System.getenv( "OPS4J_appKey" ));
 	}
 	
 }


### PR DESCRIPTION
Want to run ops4j tests in IntelliJ. In order to change value of
'server', I would need to go into the IntelliJ Run configuration for
each test and change the value passed in. Using an env setting,
if present, means can change server without needing to make any
changes to IntelliJ settings.